### PR TITLE
Streamline Project/Application names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # management-clusters-fleet
+
 GitOps for Giant Swarm management clusters
 
+## Layout
+
+- AppProject: `argocd` contains:
+  - Application: `projects` manages:
+    - `argocd` AppProject
+    - `collections` AppProject
+  - Application: `argocd` manages:
+    - Upstream Argo CD manifests stored in `build/argocd/`
+- AppProject: `collections`:
+  - Application: `provider-collection` manages:
+    - Manifests from the provider-specific app collection
 
 ## Updating Argo CD manifests
 

--- a/build/provider/aws.yaml
+++ b/build/provider/aws.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-argocd
+  name: argocd
   namespace: argocd
 spec:
   clusterResourceWhitelist:
@@ -48,7 +48,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster AWS collection
@@ -75,7 +75,7 @@ spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: build/argocd
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -88,13 +88,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: manifests/provider/aws
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -107,13 +107,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
   destination:
     namespace: giantswarm
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     path: helm/aws-app-collection-chart/templates
     repoURL: https://github.com/giantswarm/aws-app-collection.git

--- a/build/provider/azure.yaml
+++ b/build/provider/azure.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-argocd
+  name: argocd
   namespace: argocd
 spec:
   clusterResourceWhitelist:
@@ -48,7 +48,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster Azure collection
@@ -75,7 +75,7 @@ spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: build/argocd
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -88,13 +88,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: manifests/provider/azure
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -107,13 +107,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
   destination:
     namespace: giantswarm
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     path: helm/azure-app-collection-chart/templates
     repoURL: https://github.com/giantswarm/azure-app-collection.git

--- a/build/provider/kvm.yaml
+++ b/build/provider/kvm.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-argocd
+  name: argocd
   namespace: argocd
 spec:
   clusterResourceWhitelist:
@@ -48,7 +48,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster KVM Collection
@@ -75,7 +75,7 @@ spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: build/argocd
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -88,13 +88,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: manifests/provider/kvm
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -107,13 +107,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
   destination:
     namespace: giantswarm
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     path: helm/kvm-app-collection-chart/templates
     repoURL: https://github.com/giantswarm/kvm-app-collection.git

--- a/build/provider/vmware.yaml
+++ b/build/provider/vmware.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-argocd
+  name: argocd
   namespace: argocd
 spec:
   clusterResourceWhitelist:
@@ -48,7 +48,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster VMWare collection
@@ -75,7 +75,7 @@ spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: build/argocd
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -88,13 +88,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     path: manifests/provider/vmware
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
@@ -107,13 +107,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
   destination:
     namespace: giantswarm
     server: https://kubernetes.default.svc
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     path: helm/vmware-app-collection-chart/templates
     repoURL: https://github.com/giantswarm/vmware-app-collection.git

--- a/hack/update-argocd-manifests.sh
+++ b/hack/update-argocd-manifests.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -15,15 +16,13 @@ AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-quay.io/giantswarm}"
 IMAGE_TAG="${ARGOCD_VERSION:-latest}"
 
-set -x
-
 ${KUSTOMIZE} version
 
-git clone --quiet --depth 1 --branch ${ARGOCD_VERSION} ${ARGOCD_REPOSITORY} ${WORK_DIR}
+git clone --depth 1 --branch ${ARGOCD_VERSION} ${ARGOCD_REPOSITORY} ${WORK_DIR}
 cd ${WORK_DIR}
 
 cd manifests/base
-${KUSTOMIZE} edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
+${KUSTOMIZE} edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG} 
 ${KUSTOMIZE} edit set namespace argocd
 cd -
 
@@ -35,3 +34,9 @@ ${KUSTOMIZE} build "manifests/cluster-install" >> "${SRCROOT}/build/argocd/insta
 
 cd ${SRCROOT}
 rm $WORK_DIR -Rf
+
+mkdir -p ${SRCROOT}/build/provider
+for provider in $(ls ${SRCROOT}/manifests/provider); do
+  echo "${AUTOGENMSG}" > "${SRCROOT}/build/provider/${provider}.yaml"
+  ${KUSTOMIZE} build ${SRCROOT}/manifests/provider/${provider} >> "${SRCROOT}/build/provider/${provider}.yaml"
+done

--- a/hack/update-argocd-manifests.sh
+++ b/hack/update-argocd-manifests.sh
@@ -1,5 +1,4 @@
 #! /usr/bin/env bash
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -16,13 +15,15 @@ AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-quay.io/giantswarm}"
 IMAGE_TAG="${ARGOCD_VERSION:-latest}"
 
+set -x
+
 ${KUSTOMIZE} version
 
-git clone --depth 1 --branch ${ARGOCD_VERSION} ${ARGOCD_REPOSITORY} ${WORK_DIR}
+git clone --quiet --depth 1 --branch ${ARGOCD_VERSION} ${ARGOCD_REPOSITORY} ${WORK_DIR}
 cd ${WORK_DIR}
 
 cd manifests/base
-${KUSTOMIZE} edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG} 
+${KUSTOMIZE} edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 ${KUSTOMIZE} edit set namespace argocd
 cd -
 
@@ -34,9 +35,3 @@ ${KUSTOMIZE} build "manifests/cluster-install" >> "${SRCROOT}/build/argocd/insta
 
 cd ${SRCROOT}
 rm $WORK_DIR -Rf
-
-mkdir -p ${SRCROOT}/build/provider
-for provider in $(ls ${SRCROOT}/manifests/provider); do
-  echo "${AUTOGENMSG}" > "${SRCROOT}/build/provider/${provider}.yaml"
-  ${KUSTOMIZE} build ${SRCROOT}/manifests/provider/${provider} >> "${SRCROOT}/build/provider/${provider}.yaml"
-done

--- a/manifests/base/management-clusters-fleet-argocd.yaml
+++ b/manifests/base/management-clusters-fleet-argocd.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-argocd
+  name: argocd
   namespace: argocd
 spec:
   description: Management Clusters Fleet Argo CD
@@ -22,7 +22,7 @@ metadata:
   name: management-clusters-fleet-argocd
   namespace: argocd
 spec:
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
     targetRevision: main
@@ -38,10 +38,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
-  project: management-clusters-fleet-argocd
+  project: argocd
   source:
     repoURL: https://github.com/giantswarm/management-clusters-fleet.git
     targetRevision: main

--- a/manifests/base/management-clusters-fleet-collections.yaml
+++ b/manifests/base/management-clusters-fleet-collections.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   namespaceResourceBlacklist:
@@ -23,10 +23,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     targetRevision: master
   destination:

--- a/manifests/provider/aws/override.yaml
+++ b/manifests/provider/aws/override.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   source:
@@ -21,7 +21,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster AWS collection
@@ -31,10 +31,9 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
-  project: management-clusters-fleet-collection
   source:
     repoURL: https://github.com/giantswarm/aws-app-collection.git
     path: helm/aws-app-collection-chart/templates

--- a/manifests/provider/azure/override.yaml
+++ b/manifests/provider/azure/override.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   source:
@@ -21,7 +21,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster Azure collection
@@ -31,10 +31,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
-  project: management-clusters-fleet-collection
+  project: collections
   source:
     repoURL: https://github.com/giantswarm/azure-app-collection.git
     path: helm/azure-app-collection-chart/templates

--- a/manifests/provider/kvm/override.yaml
+++ b/manifests/provider/kvm/override.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   source:
@@ -21,7 +21,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster KVM Collection
@@ -31,10 +31,9 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
-  project: management-clusters-fleet-collection
   source:
     repoURL: https://github.com/giantswarm/kvm-app-collection.git
     path: helm/kvm-app-collection-chart/templates

--- a/manifests/provider/vmware/override.yaml
+++ b/manifests/provider/vmware/override.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-argocd-provider
+  name: projects
   namespace: argocd
 spec:
   source:
@@ -21,7 +21,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: management-clusters-fleet-collection
+  name: collections
   namespace: argocd
 spec:
   description: Management Cluster VMWare collection
@@ -31,10 +31,9 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: management-clusters-fleet-collection
+  name: provider-collection
   namespace: argocd
 spec:
-  project: management-clusters-fleet-collection
   source:
     repoURL: https://github.com/giantswarm/vmware-app-collection.git
     path: helm/vmware-app-collection-chart/templates


### PR DESCRIPTION
⚠️ Skip the `build` dir during the review, it's generated.

Changes:

- AppProject: `management-clusters-fleet-argocd` -> `argocd`
- Application: `management-clusters-fleet-argocd` -> `argocd`
- Application: `management-clusters-fleet-argocd-provider` -> `projects`
- AppProject: `management-clusters-fleet-collection` -> `collections`
- Applictaion: `management-clusters-fleet-collection` -> `provider-collection`

Check the REAMDE changes for the layout description.