### PR TITLE
Add explicit `namespace: default` destination

### DIFF
--- a/build/provider/aws.yaml
+++ b/build/provider/aws.yaml
@@ -60,6 +60,8 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: kube-system
     server: https://kubernetes.default.svc
+  - namespace: default
+    server: https://kubernetes.default.svc
   - server: https://kubernetes.default.svc
   namespaceResourceBlacklist:
   - group: application.giantswarm.io

--- a/build/provider/azure.yaml
+++ b/build/provider/azure.yaml
@@ -60,6 +60,8 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: kube-system
     server: https://kubernetes.default.svc
+  - namespace: default
+    server: https://kubernetes.default.svc
   - server: https://kubernetes.default.svc
   namespaceResourceBlacklist:
   - group: application.giantswarm.io

--- a/build/provider/kvm.yaml
+++ b/build/provider/kvm.yaml
@@ -60,6 +60,8 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: kube-system
     server: https://kubernetes.default.svc
+  - namespace: default
+    server: https://kubernetes.default.svc
   - server: https://kubernetes.default.svc
   namespaceResourceBlacklist:
   - group: application.giantswarm.io

--- a/build/provider/vmware.yaml
+++ b/build/provider/vmware.yaml
@@ -60,6 +60,8 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: kube-system
     server: https://kubernetes.default.svc
+  - namespace: default
+    server: https://kubernetes.default.svc
   - server: https://kubernetes.default.svc
   namespaceResourceBlacklist:
   - group: application.giantswarm.io

--- a/manifests/base/management-clusters-fleet-collections.yaml
+++ b/manifests/base/management-clusters-fleet-collections.yaml
@@ -18,6 +18,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: kube-system
       server: https://kubernetes.default.svc
+    - namespace: default
+      server: https://kubernetes.default.svc
     - server: https://kubernetes.default.svc
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
I found this out during my testing on #11. Without this setting (below) won't work.

```
 destination:
    namespace: default
    server: https://kubernetes.default.svc
```