### PR TITLE
Add Giant Swarm Application healthcheck

### DIFF
--- a/bootstrap/aws-china-test.yaml
+++ b/bootstrap/aws-china-test.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/aws-china-test.yaml
+++ b/bootstrap/aws-china-test.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/aws-china-test.yaml
+++ b/bootstrap/aws-china-test.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/aws-china.yaml
+++ b/bootstrap/aws-china.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/aws-china.yaml
+++ b/bootstrap/aws-china.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/aws-china.yaml
+++ b/bootstrap/aws-china.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/aws-test.yaml
+++ b/bootstrap/aws-test.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/aws-test.yaml
+++ b/bootstrap/aws-test.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/aws-test.yaml
+++ b/bootstrap/aws-test.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/aws.yaml
+++ b/bootstrap/aws.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/aws.yaml
+++ b/bootstrap/aws.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/aws.yaml
+++ b/bootstrap/aws.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/azure-test.yaml
+++ b/bootstrap/azure-test.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/azure-test.yaml
+++ b/bootstrap/azure-test.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/azure-test.yaml
+++ b/bootstrap/azure-test.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/azure.yaml
+++ b/bootstrap/azure.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/azure.yaml
+++ b/bootstrap/azure.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/azure.yaml
+++ b/bootstrap/azure.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/kvm-test.yaml
+++ b/bootstrap/kvm-test.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/kvm-test.yaml
+++ b/bootstrap/kvm-test.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/kvm-test.yaml
+++ b/bootstrap/kvm-test.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/kvm.yaml
+++ b/bootstrap/kvm.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/kvm.yaml
+++ b/bootstrap/kvm.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/kvm.yaml
+++ b/bootstrap/kvm.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/vmware-test.yaml
+++ b/bootstrap/vmware-test.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/vmware-test.yaml
+++ b/bootstrap/vmware-test.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/vmware-test.yaml
+++ b/bootstrap/vmware-test.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/bootstrap/vmware.yaml
+++ b/bootstrap/vmware.yaml
@@ -2896,6 +2896,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -2908,6 +2912,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/bootstrap/vmware.yaml
+++ b/bootstrap/vmware.yaml
@@ -2884,27 +2884,29 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/bootstrap/vmware.yaml
+++ b/bootstrap/vmware.yaml
@@ -2884,6 +2884,35 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/argocd/argocd-cm.yaml
+++ b/manifests/argocd/argocd-cm.yaml
@@ -24,27 +24,29 @@ data:
           --name=${ARGOCD_APP_NAME}"
   # Helm status: https://github.com/helm/helm/blob/main/pkg/release/status.go
   # ArgoCD status: https://github.com/argoproj/gitops-engine/blob/master/pkg/health/health.go
-  resource.customizations.health.application.giantswarm.io_Application: |
+  resource.customizations.health.application.giantswarm.io_App: |
     hs = {}
     hs.status = "Progressing"
     hs.message = "Waiting for Chart to be installed"
     if obj.status ~= nil then
       if obj.status.release ~= nil then
-        if obj.status.release.status == "Deployed" then
+        if obj.status.release.status == "already-exists" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "deployed" then
           hs.status = "Healthy"
-        elseif obj.status.release.status == "Failed" then
+        elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "PendingInstall" then
+        elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingRollback" then
+        elseif obj.status.release.status == "pending-rollback" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "PendingUpgrade" then
+        elseif obj.status.release.status == "pending-upgrade" then
           hs.status = "Progressing"
-        elseif obj.status.release.status == "Superseded" then
+        elseif obj.status.release.status == "superseded" then
           hs.status = "Suspended"
-        elseif obj.status.release.status == "Uninstalled" then
+        elseif obj.status.release.status == "uninstalled" then
           hs.status = "Degraded"
-        elseif obj.status.release.status == "Uninstalling" then
+        elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
         else
           hs.status = "Unknown"

--- a/manifests/argocd/argocd-cm.yaml
+++ b/manifests/argocd/argocd-cm.yaml
@@ -36,6 +36,10 @@ data:
           hs.status = "Healthy"
         elseif obj.status.release.status == "failed" then
           hs.status = "Degraded"
+        elseif obj.status.release.status == "invalid-manifest" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "not-installed" then
+          hs.status = "Degraded"
         elseif obj.status.release.status == "pending-install" then
           hs.status = "Progressing"
         elseif obj.status.release.status == "pending-rollback" then
@@ -48,6 +52,8 @@ data:
           hs.status = "Degraded"
         elseif obj.status.release.status == "uninstalling" then
           hs.status = "Progressing"
+        elseif obj.status.release.status == "validation-failed" then
+          hs.status = "Degraded"
         else
           hs.status = "Unknown"
         end

--- a/manifests/argocd/argocd-cm.yaml
+++ b/manifests/argocd/argocd-cm.yaml
@@ -22,3 +22,34 @@ data:
           --app-catalog=${KONFIGURE_APP_CATALOG}
           --app-version=${KONFIGURE_APP_VERSION}
           --name=${ARGOCD_APP_NAME}"
+  # Helm status: https://github.com/helm/helm/blob/main/pkg/release/status.go
+  # ArgoCD status: https://github.com/argoproj/gitops-engine/blob/master/pkg/health/health.go
+  resource.customizations.health.application.giantswarm.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for Chart to be installed"
+    if obj.status ~= nil then
+      if obj.status.release ~= nil then
+        if obj.status.release.status == "Deployed" then
+          hs.status = "Healthy"
+        elseif obj.status.release.status == "Failed" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "PendingInstall" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingRollback" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "PendingUpgrade" then
+          hs.status = "Progressing"
+        elseif obj.status.release.status == "Superseded" then
+          hs.status = "Suspended"
+        elseif obj.status.release.status == "Uninstalled" then
+          hs.status = "Degraded"
+        elseif obj.status.release.status == "Uninstalling" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Unknown"
+        end
+        hs.message = obj.status.release.reason
+      end
+    end
+    return hs


### PR DESCRIPTION
Adds a status conversion function in Lua, which enables ArgoCD to understand our CR's status. We gain nicer reporting/alerting and prettier dashboards:

![Screenshot_20211028_122932](https://user-images.githubusercontent.com/4587658/139239026-c2560553-f4b1-4c07-b738-bca986bf61fb.jpeg)

![Screenshot_20211028_122914](https://user-images.githubusercontent.com/4587658/139239085-30397c5a-b32e-49ad-a3ae-074d7ba95610.jpeg)

![image](https://user-images.githubusercontent.com/4587658/139239252-fc63e00b-3eba-4442-b0c8-f0a417b5d772.png)

```
gauss:thinkbook:~ k get application -n argocd | grep -v Healthy
NAME                                     SYNC STATUS   HEALTH STATUS
releases-aws                             Synced        Degraded
```