### PR TITLE
Update kyverno

### DIFF
--- a/bootstrap/customer-aws/customer-aws.yaml
+++ b/bootstrap/customer-aws/customer-aws.yaml
@@ -1191,8 +1191,62 @@ spec:
       foreach:
       - list: request.object.spec.eventSources
         pattern:
-          namespace: '{{request.object.metadata.namespace}}'
+          =(namespace): '{{request.object.metadata.namespace}}'
       message: spec.eventSources namespaces must be the same as metadata.namespace
+  - exclude:
+      resources:
+        namespaces:
+        - flux-system
+        - flux-giantswarm
+        - giantswarm
+        - monitoring
+    match:
+      resources:
+        kinds:
+        - Receiver
+    name: receiverResourcesMustBeLocal
+    validate:
+      foreach:
+      - list: request.object.spec.resources
+        pattern:
+          =(namespace): '{{request.object.metadata.namespace}}'
+      message: spec.resources namespaces must be the same as metadata.namespace
+  - exclude:
+      resources:
+        namespaces:
+        - flux-system
+        - flux-giantswarm
+        - giantswarm
+        - monitoring
+    match:
+      resources:
+        kinds:
+        - Event
+    name: eventsObjectMustBeLocal
+    validate:
+      message: spec.involvedObject namespace must be the same as metadata.namespace
+      pattern:
+        spec:
+          involvedObject:
+            =(namespace): '{{request.object.metadata.namespace}}'
+  - exclude:
+      resources:
+        namespaces:
+        - flux-system
+        - flux-giantswarm
+        - giantswarm
+        - monitoring
+    match:
+      resources:
+        kinds:
+        - ImagePolicy
+    name: imagePolicyRepositoryMustBeLocal
+    validate:
+      message: spec.imageRepositoryRef namespace must be the same as metadata.namespace
+      pattern:
+        spec:
+          imageRepositoryRef:
+            namespace: '{{request.object.metadata.namespace}}'
   validationFailureAction: enforce
 ---
 apiVersion: networking.k8s.io/v1

--- a/bootstrap/customer-aws/customer-aws.yaml
+++ b/bootstrap/customer-aws/customer-aws.yaml
@@ -1054,7 +1054,7 @@ spec:
       resources:
         namespaces:
         - flux-system
-        - giantswarm-flux
+        - flux-giantswarm
         - giantswarm
         - monitoring
     match:
@@ -1062,7 +1062,7 @@ spec:
         kinds:
         - Kustomization
         - HelmRelease
-    name: serviceAccountName
+    name: serviceAccountNameMustBeSet
     validate:
       message: .spec.serviceAccountName is required
       pattern:
@@ -1072,15 +1072,14 @@ spec:
       resources:
         namespaces:
         - flux-system
-        - giantswarm-flux
+        - flux-giantswarm
         - giantswarm
         - monitoring
     match:
       resources:
         kinds:
         - Kustomization
-        - HelmRelease
-    name: sourceRefNamespace
+    name: kustomizationSourceRefNamespaceIsSafe
     preconditions:
       any:
       - key: '{{request.object.spec.sourceRef.namespace}}'
@@ -1089,15 +1088,49 @@ spec:
     validate:
       deny:
         conditions:
-        - key: '{{request.object.spec.sourceRef.namespace}}'
-          operator: NotEquals
-          value: '{{request.object.metadata.namespace}}'
-      message: spec.sourceRef.namespace must be the same as metadata.namespace
+          all:
+          - key: '{{request.object.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: '{{request.object.metadata.namespace}}'
+          - key: '{{request.object.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: default
+      message: spec.sourceRef.namespace must be the same as metadata.namespace or
+        'default'
   - exclude:
       resources:
         namespaces:
         - flux-system
-        - giantswarm-flux
+        - flux-giantswarm
+        - giantswarm
+        - monitoring
+    match:
+      resources:
+        kinds:
+        - HelmRelease
+    name: helmReleaseSourceRefNamespaceIsSafe
+    preconditions:
+      any:
+      - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+        operator: NotEquals
+        value: ""
+    validate:
+      deny:
+        conditions:
+          all:
+          - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: '{{request.object.metadata.namespace}}'
+          - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: default
+      message: spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
+        or 'default'
+  - exclude:
+      resources:
+        namespaces:
+        - flux-system
+        - flux-giantswarm
         - giantswarm
         - monitoring
     match:
@@ -1105,7 +1138,7 @@ spec:
         kinds:
         - Kustomization
         - HelmRelease
-    name: targetNamespace
+    name: targetNamespaceMustBeLocal
     preconditions:
       any:
       - key: '{{request.object.spec.targetNamespace}}'
@@ -1122,14 +1155,14 @@ spec:
       resources:
         namespaces:
         - flux-system
-        - giantswarm-flux
+        - flux-giantswarm
         - giantswarm
         - monitoring
     match:
       resources:
         kinds:
         - HelmRelease
-    name: storageNamespace
+    name: storageNamespaceMustBeLocal
     preconditions:
       any:
       - key: '{{request.object.spec.storageNamespace}}'
@@ -1142,6 +1175,24 @@ spec:
           operator: NotEquals
           value: '{{request.object.metadata.namespace}}'
       message: spec.storageNamespace must be the same as metadata.namespace
+  - exclude:
+      resources:
+        namespaces:
+        - flux-system
+        - flux-giantswarm
+        - giantswarm
+        - monitoring
+    match:
+      resources:
+        kinds:
+        - Alert
+    name: alertEventSourcesMustBeLocal
+    validate:
+      foreach:
+      - list: request.object.spec.eventSources
+        pattern:
+          namespace: '{{request.object.metadata.namespace}}'
+      message: spec.eventSources namespaces must be the same as metadata.namespace
   validationFailureAction: enforce
 ---
 apiVersion: networking.k8s.io/v1

--- a/bootstrap/gs-aws-china/gs-aws-china.yaml
+++ b/bootstrap/gs-aws-china/gs-aws-china.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: giantswarm-flux
+  name: flux-giantswarm
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5451,17 +5451,17 @@ metadata:
     helm.sh/hook-weight: "-4"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5469,13 +5469,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5483,13 +5483,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5497,13 +5497,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5511,13 +5511,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5525,19 +5525,19 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5545,7 +5545,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -5556,7 +5556,7 @@ metadata:
     helm.sh/hook-weight: "-6"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
@@ -5587,7 +5587,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/version: 0.21.0
@@ -5620,7 +5620,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 rules:
 - apiGroups:
   - ""
@@ -5638,11 +5638,11 @@ metadata:
     helm.sh/hook-weight: "-3"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 rules:
 - apiGroups:
   - ""
@@ -5673,7 +5673,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5766,7 +5766,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -5774,7 +5774,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5785,13 +5785,13 @@ metadata:
     helm.sh/hook-weight: "-2"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     helm.sh/chart: flux-app-0.7.1
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5799,13 +5799,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5820,16 +5820,16 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5844,22 +5844,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6047,11 +6047,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-alert
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6251,11 +6251,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-bucket
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6536,11 +6536,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-gitrepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6757,11 +6757,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmchart
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7325,11 +7325,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmrelease
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7513,11 +7513,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmrepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7966,11 +7966,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imagepolicy
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -8402,11 +8402,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imagerepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -9032,11 +9032,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imageupdateautomation
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -9884,11 +9884,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-kustomization
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -10067,11 +10067,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-provider
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -10267,11 +10267,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-receiver
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: Service
@@ -10280,15 +10280,15 @@ metadata:
     giantswarm.io/monitoring-path: /metrics
     giantswarm.io/monitoring-port: "8080"
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/version: 0.21.0
     giantswarm.io/monitoring: "true"
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
-  name: giantswarm-flux-monitoring
-  namespace: giantswarm-flux
+  name: flux-giantswarm-monitoring
+  namespace: flux-giantswarm
 spec:
   clusterIP: None
   ports:
@@ -10296,7 +10296,7 @@ spec:
     protocol: TCP
     targetPort: http-prom
   selector:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
 ---
@@ -10304,7 +10304,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10313,7 +10313,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10322,7 +10322,7 @@ spec:
     targetPort: http
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10331,7 +10331,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10340,7 +10340,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10349,7 +10349,7 @@ spec:
     targetPort: http
   selector:
     app: source-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10358,7 +10358,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10367,7 +10367,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: webhook-receiver
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10376,7 +10376,7 @@ spec:
     targetPort: http-webhook
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10386,7 +10386,7 @@ kind: Deployment
 metadata:
   labels:
     app: helm-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10395,13 +10395,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: helm-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10411,7 +10411,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: helm-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10472,7 +10472,7 @@ kind: Deployment
 metadata:
   labels:
     app: image-automation-controlller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10481,13 +10481,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-automation-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10497,7 +10497,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-automation-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10560,7 +10560,7 @@ kind: Deployment
 metadata:
   labels:
     app: image-reflector-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10569,13 +10569,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-reflector-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10585,7 +10585,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-reflector-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10652,7 +10652,7 @@ kind: Deployment
 metadata:
   labels:
     app: kustomize-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10661,13 +10661,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: kustomize-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10677,7 +10677,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: kustomize-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10700,9 +10700,9 @@ spec:
               key: NAME
               name: management-cluster-metadata
         - name: KONFIGURE_GITREPO
-          value: giantswarm-flux/giantswarm-config
+          value: flux-giantswarm/giantswarm-config
         - name: KONFIGURE_SOURCE_SERVICE
-          value: source-controller.giantswarm-flux.svc
+          value: source-controller.flux-giantswarm.svc
         - name: VAULT_ADDR
           valueFrom:
             configMapKeyRef:
@@ -10791,7 +10791,7 @@ spec:
         - --vault-address=$(VAULT_ADDR)
         - --vault-role=konfigure
         - --vault-token-secret-name=flux-vault-token
-        - --vault-token-secret-namespace=giantswarm-flux
+        - --vault-token-secret-namespace=flux-giantswarm
         env:
         - name: VAULT_ADDR
           valueFrom:
@@ -10828,7 +10828,7 @@ kind: Deployment
 metadata:
   labels:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10837,13 +10837,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10853,7 +10853,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: notification-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10917,7 +10917,7 @@ kind: Deployment
 metadata:
   labels:
     app: source-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10926,13 +10926,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: source-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   strategy:
@@ -10944,7 +10944,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: source-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -11017,7 +11017,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   jobTemplate:
     spec:
@@ -11027,7 +11027,7 @@ spec:
           - args:
             - delete
             - pods
-            - --namespace=giantswarm-flux
+            - --namespace=flux-giantswarm
             - -lapp=kustomize-controller
             image: docker.io/giantswarm/docker-kubectl:1.18.8
             name: restart-kustomize-controller
@@ -11036,7 +11036,7 @@ spec:
             - --vault-address=$(VAULT_ADDR)
             - --vault-role=konfigure
             - --vault-token-secret-name=flux-vault-token
-            - --vault-token-secret-namespace=giantswarm-flux
+            - --vault-token-secret-namespace=flux-giantswarm
             env:
             - name: VAULT_ADDR
               valueFrom:
@@ -11059,18 +11059,18 @@ metadata:
     helm.sh/hook-weight: "-1"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   backoffLimit: 4
   template:
     metadata:
       labels:
         app.kubernetes.io/component: flux-app-crd-install
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/name: flux-app
     spec:
       containers:
@@ -11218,7 +11218,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: collection
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 10s
   path: ./manifests
@@ -11226,14 +11226,14 @@ spec:
   sourceRef:
     kind: GitRepository
     name: collection
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
   targetNamespace: giantswarm
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: customer-flux
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   path: ./bootstrap/customer-aws
@@ -11241,13 +11241,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: management-clusters-fleet
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: flux
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   path: ./bootstrap/gs-aws-china
@@ -11255,13 +11255,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: management-clusters-fleet
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11269,7 +11269,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-egress
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - {}
@@ -11285,7 +11285,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11293,7 +11293,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-scraping
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - {}
@@ -11303,7 +11303,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   policyTypes:
@@ -11314,7 +11314,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11322,7 +11322,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-webhooks
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ingress:
   - from:
@@ -11330,7 +11330,7 @@ spec:
   podSelector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   policyTypes:
@@ -11345,11 +11345,11 @@ metadata:
     helm.sh/hook-weight: "-7"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - ports:
@@ -11370,7 +11370,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/component: flux-app-crd-install
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/name: flux-app
   policyTypes:
   - Egress
@@ -11380,7 +11380,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: collection
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:
@@ -11394,7 +11394,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: giantswarm-config
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:
@@ -11407,7 +11407,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: management-clusters-fleet
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:

--- a/bootstrap/gs-aws/gs-aws.yaml
+++ b/bootstrap/gs-aws/gs-aws.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: giantswarm-flux
+  name: flux-giantswarm
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5451,17 +5451,17 @@ metadata:
     helm.sh/hook-weight: "-4"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5469,13 +5469,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5483,13 +5483,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5497,13 +5497,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5511,13 +5511,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5525,19 +5525,19 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5545,7 +5545,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -5556,7 +5556,7 @@ metadata:
     helm.sh/hook-weight: "-6"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
@@ -5587,7 +5587,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/version: 0.21.0
@@ -5620,7 +5620,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 rules:
 - apiGroups:
   - ""
@@ -5638,11 +5638,11 @@ metadata:
     helm.sh/hook-weight: "-3"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 rules:
 - apiGroups:
   - ""
@@ -5673,7 +5673,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5766,7 +5766,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -5774,7 +5774,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5785,13 +5785,13 @@ metadata:
     helm.sh/hook-weight: "-2"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     helm.sh/chart: flux-app-0.7.1
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5799,13 +5799,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5820,16 +5820,16 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -5844,22 +5844,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 - kind: ServiceAccount
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6047,11 +6047,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-alert
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6251,11 +6251,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-bucket
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6536,11 +6536,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-gitrepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -6757,11 +6757,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmchart
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7325,11 +7325,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmrelease
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7513,11 +7513,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-helmrepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -7966,11 +7966,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imagepolicy
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -8402,11 +8402,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imagerepository
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -9032,11 +9032,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-imageupdateautomation
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -9884,11 +9884,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-kustomization
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -10067,11 +10067,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-provider
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 data:
@@ -10267,11 +10267,11 @@ metadata:
     helm.sh/hook-weight: "-5"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install-receiver
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 ---
 apiVersion: v1
 kind: Service
@@ -10280,15 +10280,15 @@ metadata:
     giantswarm.io/monitoring-path: /metrics
     giantswarm.io/monitoring-port: "8080"
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/version: 0.21.0
     giantswarm.io/monitoring: "true"
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
-  name: giantswarm-flux-monitoring
-  namespace: giantswarm-flux
+  name: flux-giantswarm-monitoring
+  namespace: flux-giantswarm
 spec:
   clusterIP: None
   ports:
@@ -10296,7 +10296,7 @@ spec:
     protocol: TCP
     targetPort: http-prom
   selector:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
 ---
@@ -10304,7 +10304,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10313,7 +10313,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10322,7 +10322,7 @@ spec:
     targetPort: http
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10331,7 +10331,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10340,7 +10340,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10349,7 +10349,7 @@ spec:
     targetPort: http
   selector:
     app: source-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10358,7 +10358,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10367,7 +10367,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: webhook-receiver
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ports:
   - name: http
@@ -10376,7 +10376,7 @@ spec:
     targetPort: http-webhook
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
   type: ClusterIP
@@ -10386,7 +10386,7 @@ kind: Deployment
 metadata:
   labels:
     app: helm-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10395,13 +10395,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: helm-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: helm-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10411,7 +10411,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: helm-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10472,7 +10472,7 @@ kind: Deployment
 metadata:
   labels:
     app: image-automation-controlller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10481,13 +10481,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-automation-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-automation-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10497,7 +10497,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-automation-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10560,7 +10560,7 @@ kind: Deployment
 metadata:
   labels:
     app: image-reflector-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10569,13 +10569,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: image-reflector-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-reflector-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10585,7 +10585,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-reflector-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10652,7 +10652,7 @@ kind: Deployment
 metadata:
   labels:
     app: kustomize-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10661,13 +10661,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: kustomize-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: kustomize-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10677,7 +10677,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: kustomize-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10700,9 +10700,9 @@ spec:
               key: NAME
               name: management-cluster-metadata
         - name: KONFIGURE_GITREPO
-          value: giantswarm-flux/giantswarm-config
+          value: flux-giantswarm/giantswarm-config
         - name: KONFIGURE_SOURCE_SERVICE
-          value: source-controller.giantswarm-flux.svc
+          value: source-controller.flux-giantswarm.svc
         - name: VAULT_ADDR
           valueFrom:
             configMapKeyRef:
@@ -10791,7 +10791,7 @@ spec:
         - --vault-address=$(VAULT_ADDR)
         - --vault-role=konfigure
         - --vault-token-secret-name=flux-vault-token
-        - --vault-token-secret-namespace=giantswarm-flux
+        - --vault-token-secret-namespace=flux-giantswarm
         env:
         - name: VAULT_ADDR
           valueFrom:
@@ -10828,7 +10828,7 @@ kind: Deployment
 metadata:
   labels:
     app: notification-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10837,13 +10837,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: notification-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   template:
@@ -10853,7 +10853,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: notification-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -10917,7 +10917,7 @@ kind: Deployment
 metadata:
   labels:
     app: source-controller
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -10926,13 +10926,13 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: source-controller
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: source-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   strategy:
@@ -10944,7 +10944,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: source-controller
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: flux-app
         app.kubernetes.io/version: 0.21.0
@@ -11013,7 +11013,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   jobTemplate:
     spec:
@@ -11023,7 +11023,7 @@ spec:
           - args:
             - delete
             - pods
-            - --namespace=giantswarm-flux
+            - --namespace=flux-giantswarm
             - -lapp=kustomize-controller
             image: docker.io/giantswarm/docker-kubectl:1.18.8
             name: restart-kustomize-controller
@@ -11032,7 +11032,7 @@ spec:
             - --vault-address=$(VAULT_ADDR)
             - --vault-role=konfigure
             - --vault-token-secret-name=flux-vault-token
-            - --vault-token-secret-namespace=giantswarm-flux
+            - --vault-token-secret-namespace=flux-giantswarm
             env:
             - name: VAULT_ADDR
               valueFrom:
@@ -11055,18 +11055,18 @@ metadata:
     helm.sh/hook-weight: "-1"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   backoffLimit: 4
   template:
     metadata:
       labels:
         app.kubernetes.io/component: flux-app-crd-install
-        app.kubernetes.io/instance: giantswarm-flux
+        app.kubernetes.io/instance: flux-giantswarm
         app.kubernetes.io/name: flux-app
     spec:
       containers:
@@ -11214,7 +11214,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: collection
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 10s
   path: ./manifests
@@ -11222,14 +11222,14 @@ spec:
   sourceRef:
     kind: GitRepository
     name: collection
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
   targetNamespace: giantswarm
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: customer-flux
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   path: ./bootstrap/customer-aws
@@ -11237,13 +11237,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: management-clusters-fleet
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: flux
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   path: ./bootstrap/gs-aws
@@ -11251,13 +11251,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: management-clusters-fleet
-    namespace: giantswarm-flux
+    namespace: flux-giantswarm
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11265,7 +11265,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-egress
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - {}
@@ -11281,7 +11281,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11289,7 +11289,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-scraping
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - {}
@@ -11299,7 +11299,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   policyTypes:
@@ -11310,7 +11310,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: flux-app
     app.kubernetes.io/part-of: flux
@@ -11318,7 +11318,7 @@ metadata:
     giantswarm.io/service_type: managed
     helm.sh/chart: flux-app-0.7.1
   name: allow-webhooks
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   ingress:
   - from:
@@ -11326,7 +11326,7 @@ spec:
   podSelector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: flux-app
   policyTypes:
@@ -11341,11 +11341,11 @@ metadata:
     helm.sh/hook-weight: "-7"
   labels:
     app.kubernetes.io/component: flux-app-crd-install
-    app.kubernetes.io/instance: giantswarm-flux
+    app.kubernetes.io/instance: flux-giantswarm
     app.kubernetes.io/name: flux-app
     role: crd-install-hook
   name: flux-app-crd-install
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   egress:
   - ports:
@@ -11366,7 +11366,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/component: flux-app-crd-install
-      app.kubernetes.io/instance: giantswarm-flux
+      app.kubernetes.io/instance: flux-giantswarm
       app.kubernetes.io/name: flux-app
   policyTypes:
   - Egress
@@ -11376,7 +11376,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: collection
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:
@@ -11390,7 +11390,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: giantswarm-config
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:
@@ -11403,7 +11403,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: management-clusters-fleet
-  namespace: giantswarm-flux
+  namespace: flux-giantswarm
 spec:
   interval: 30s
   ref:

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -145,7 +145,7 @@ spec:
         foreach:
         - list: "request.object.spec.eventSources"
           pattern:
-            namespace: "{{request.object.metadata.namespace}}"
+            =(namespace): "{{request.object.metadata.namespace}}"
     - name: receiverResourcesMustBeLocal
       exclude:
         resources:
@@ -157,13 +157,13 @@ spec:
       match:
         resources:
           kinds:
-            - Alert
+            - Receiver
       validate:
         message: "spec.resources namespaces must be the same as metadata.namespace"
         foreach:
         - list: "request.object.spec.resources"
           pattern:
-            namespace: "{{request.object.metadata.namespace}}"
+            =(namespace): "{{request.object.metadata.namespace}}"
     - name: eventsObjectMustBeLocal
       exclude:
         resources:
@@ -181,7 +181,7 @@ spec:
         pattern:
           spec:
             involvedObject:
-              namespace: "{{request.object.metadata.namespace}}"
+              =(namespace): "{{request.object.metadata.namespace}}"
     - name: imagePolicyRepositoryMustBeLocal
       exclude:
         resources:

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -69,7 +69,7 @@ spec:
             operator: NotEquals
             value: ""
       validate:
-        message: "spec.sourceRef.namespace must be the same as metadata.namespace or 'default'"
+        message: "spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace or 'default'"
         deny:
           conditions:
             all:
@@ -128,3 +128,31 @@ spec:
             - key: "{{request.object.spec.storageNamespace}}"
               operator: NotEquals
               value:  "{{request.object.metadata.namespace}}"
+    - name: alertEventSourcesMustBeLocal
+      exclude:
+        resources:
+          namespaces:
+            - "flux-system"
+            - "flux-giantswarm"
+            - "giantswarm"
+            - "monitoring"
+      match:
+        resources:
+          kinds:
+            - Alert # spec.eventSourcer.[*].namespace
+      preconditions:
+        any:
+          - key: "{{request.object.spec.storageNamespace}}"
+            operator: NotEquals
+            value: ""
+      validate:
+        message: "spec.storageNamespace must be the same as metadata.namespace"
+        deny:
+          conditions:
+            - key: "{{request.object.spec.storageNamespace}}"
+              operator: NotEquals
+              value:  "{{request.object.metadata.namespace}}"
+
+# Event -> spec.InvolvedObject.Namespace
+# Receiver -> spec.Resources.[*].Namespace
+# ImagePolicy -> spec.ImageRepositoryRef.Namespace

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   validationFailureAction: enforce
   rules:
-    - name: serviceAccountName
+    - name: serviceAccountNameMustBeSet
       exclude:
         resources:
           namespaces:
@@ -23,7 +23,7 @@ spec:
         pattern:
           spec:
             serviceAccountName: "?*"
-    - name: sourceRefNamespace
+    - name: sourceRefNamespaceIsSafe
       exclude:
         resources:
           namespaces:
@@ -42,13 +42,17 @@ spec:
             operator: NotEquals
             value: ""
       validate:
-        message: "spec.sourceRef.namespace must be the same as metadata.namespace"
+        message: "spec.sourceRef.namespace must be the same as metadata.namespace or 'default'"
         deny:
           conditions:
-            - key: "{{request.object.spec.sourceRef.namespace}}"
-              operator: NotEquals
-              value:  "{{request.object.metadata.namespace}}"
-    - name: targetNamespace
+            all:
+              - key: "{{request.object.spec.sourceRef.namespace}}"
+                operator: NotEquals
+                value:  "{{request.object.metadata.namespace}}"
+              - key: "{{request.object.spec.sourceRef.namespace}}"
+                operator: NotEquals
+                value:  "default"
+    - name: targetNamespaceMustBeLocal
       exclude:
         resources:
           namespaces:
@@ -73,7 +77,7 @@ spec:
             - key: "{{request.object.spec.targetNamespace}}"
               operator: NotEquals
               value:  "{{request.object.metadata.namespace}}"
-    - name: storageNamespace
+    - name: storageNamespaceMustBeLocal
       exclude:
         resources:
           namespaces:

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -139,19 +139,13 @@ spec:
       match:
         resources:
           kinds:
-            - Alert # spec.eventSourcer.[*].namespace
-      preconditions:
-        any:
-          - key: "{{request.object.spec.storageNamespace}}"
-            operator: NotEquals
-            value: ""
+            - Alert # spec.eventSources.[*].namespace
       validate:
-        message: "spec.storageNamespace must be the same as metadata.namespace"
-        deny:
-          conditions:
-            - key: "{{request.object.spec.storageNamespace}}"
-              operator: NotEquals
-              value:  "{{request.object.metadata.namespace}}"
+        message: "spec.eventSources namespaces must be the same as metadata.namespace"
+        foreach:
+        - list: "request.object.spec.eventSources"
+          pattern:
+            namespace: "{{request.object.metadata.namespace}}"
 
 # Event -> spec.InvolvedObject.Namespace
 # Receiver -> spec.Resources.[*].Namespace

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -139,14 +139,65 @@ spec:
       match:
         resources:
           kinds:
-            - Alert # spec.eventSources.[*].namespace
+            - Alert
       validate:
         message: "spec.eventSources namespaces must be the same as metadata.namespace"
         foreach:
         - list: "request.object.spec.eventSources"
           pattern:
             namespace: "{{request.object.metadata.namespace}}"
+    - name: receiverResourcesMustBeLocal
+      exclude:
+        resources:
+          namespaces:
+            - "flux-system"
+            - "flux-giantswarm"
+            - "giantswarm"
+            - "monitoring"
+      match:
+        resources:
+          kinds:
+            - Alert
+      validate:
+        message: "spec.resources namespaces must be the same as metadata.namespace"
+        foreach:
+        - list: "request.object.spec.resources"
+          pattern:
+            namespace: "{{request.object.metadata.namespace}}"
+    - name: eventsObjectMustBeLocal
+      exclude:
+        resources:
+          namespaces:
+            - "flux-system"
+            - "flux-giantswarm"
+            - "giantswarm"
+            - "monitoring"
+      match:
+        resources:
+          kinds:
+            - Event
+      validate:
+        message: "spec.involvedObject namespace must be the same as metadata.namespace"
+        pattern:
+          spec:
+            involvedObject:
+              namespace: "{{request.object.metadata.namespace}}"
+    - name: imagePolicyRepositoryMustBeLocal
+      exclude:
+        resources:
+          namespaces:
+            - "flux-system"
+            - "flux-giantswarm"
+            - "giantswarm"
+            - "monitoring"
+      match:
+        resources:
+          kinds:
+            - ImagePolicy
+      validate:
+        message: "spec.imageRepositoryRef namespace must be the same as metadata.namespace"
+        pattern:
+          spec:
+            imageRepositoryRef:
+              namespace: "{{request.object.metadata.namespace}}"
 
-# Event -> spec.InvolvedObject.Namespace
-# Receiver -> spec.Resources.[*].Namespace
-# ImagePolicy -> spec.ImageRepositoryRef.Namespace

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -23,7 +23,7 @@ spec:
         pattern:
           spec:
             serviceAccountName: "?*"
-    - name: sourceRefNamespaceIsSafe
+    - name: kustomizationSourceRefNamespaceIsSafe
       exclude:
         resources:
           namespaces:
@@ -35,7 +35,6 @@ spec:
         resources:
           kinds:
             - Kustomization
-            - HelmRelease
       preconditions:
         any:
           - key: "{{request.object.spec.sourceRef.namespace}}"
@@ -50,6 +49,34 @@ spec:
                 operator: NotEquals
                 value:  "{{request.object.metadata.namespace}}"
               - key: "{{request.object.spec.sourceRef.namespace}}"
+                operator: NotEquals
+                value:  "default"
+    - name: helmReleaseSourceRefNamespaceIsSafe
+      exclude:
+        resources:
+          namespaces:
+            - "flux-system"
+            - "flux-giantswarm"
+            - "giantswarm"
+            - "monitoring"
+      match:
+        resources:
+          kinds:
+            - HelmRelease
+      preconditions:
+        any:
+          - key: "{{request.object.spec.chart.spec.sourceRef.namespace}}"
+            operator: NotEquals
+            value: ""
+      validate:
+        message: "spec.sourceRef.namespace must be the same as metadata.namespace or 'default'"
+        deny:
+          conditions:
+            all:
+              - key: "{{request.object.spec.chart.spec.sourceRef.namespace}}"
+                operator: NotEquals
+                value:  "{{request.object.metadata.namespace}}"
+              - key: "{{request.object.spec.chart.spec.sourceRef.namespace}}"
                 operator: NotEquals
                 value:  "default"
     - name: targetNamespaceMustBeLocal


### PR DESCRIPTION
- allows to reference `GitSource` from `default` namespace (RBAC still needed)
- fix: `HelmRelease` uses different structure for `sourceRef`
- better names for checks
- added additional checks for `Alerts`, `Events`, `ImagePolicy` and Receiver` to restrict namespaces they can use