### PR TITLE
Add rest-api collection

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -21,7 +21,6 @@ BOOTSTRAP_DEPS += bootstrap/customer-aws/customer-aws.yaml
 BOOTSTRAP_DEPS += bootstrap/customer-aws-china/customer-aws-china.yaml
 BOOTSTRAP_DEPS += bootstrap/customer-azure/customer-azure.yaml
 BOOTSTRAP_DEPS += bootstrap/customer-gcp/customer-gcp.yaml
-BOOTSTRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
 BOOTSTRAP_DEPS += bootstrap/customer-kvm/customer-kvm.yaml
 BOOTSTRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
 BOOTSTRAP_DEPS += bootstrap/gs-aws/gs-aws.yaml

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -14,26 +14,27 @@ manifests/flux-app: FLUXAPP_VERSION := v0.7.1
 manifests/flux-app:
 	@echo "====> $@"
 	git clean -fxd manifests/provider/
-	find manifests/provider/ -wholename '*/kustomization.yaml' | grep -v 'charts' | xargs -I{} sed -i "0,/version:/{s/version: .*/version: $(FLUXAPP_VERSION)/g}" {}
+	find manifests/provider/ -wholename '*/kustomization.yaml' | grep -v 'charts' | xargs -I{} gsed -i "0,/version:/{s/version: .*/version: $(FLUXAPP_VERSION)/g}" {}
 
-BOOTSRAP_DEPS :=
-BOOTSRAP_DEPS += bootstrap/customer-aws/customer-aws.yaml
-BOOTSRAP_DEPS += bootstrap/customer-aws-china/customer-aws-china.yaml
-BOOTSRAP_DEPS += bootstrap/customer-azure/customer-azure.yaml
-BOOTSRAP_DEPS += bootstrap/customer-gcp/customer-gcp.yaml
-BOOTSRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
-BOOTSRAP_DEPS += bootstrap/customer-kvm/customer-kvm.yaml
-BOOTSRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
-BOOTSRAP_DEPS += bootstrap/gs-aws/gs-aws.yaml
-BOOTSRAP_DEPS += bootstrap/gs-aws-china/gs-aws-china.yaml
-BOOTSRAP_DEPS += bootstrap/gs-azure/gs-azure.yaml
-BOOTSRAP_DEPS += bootstrap/gs-gcp/gs-gcp.yaml
-BOOTSRAP_DEPS += bootstrap/gs-kvm/gs-kvm.yaml
-BOOTSRAP_DEPS += bootstrap/gs-openstack/gs-openstack.yaml
-BOOTSRAP_DEPS += bootstrap/gs-openstack-galaxy/gs-openstack-galaxy.yaml
-BOOTSRAP_DEPS += bootstrap/gs-openstack-gamma/gs-openstack-gamma.yaml
-BOOTSRAP_DEPS += bootstrap/gs-openstack-gravity/gs-openstack-gravity.yaml
-bootstrap: $(BOOTSRAP_DEPS)
+BOOTSTRAP_DEPS :=
+BOOTSTRAP_DEPS += bootstrap/customer-aws/customer-aws.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-aws-china/customer-aws-china.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-azure/customer-azure.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-gcp/customer-gcp.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-kvm/customer-kvm.yaml
+BOOTSTRAP_DEPS += bootstrap/customer-openstack/customer-openstack.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-aws/gs-aws.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-aws-china/gs-aws-china.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-azure/gs-azure.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-gcp/gs-gcp.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-kvm/gs-kvm.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-openstack/gs-openstack.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-openstack-galaxy/gs-openstack-galaxy.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-openstack-gamma/gs-openstack-gamma.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-openstack-gravity/gs-openstack-gravity.yaml
+BOOTSTRAP_DEPS += bootstrap/gs-rest-api/gs-rest-api.yaml
+bootstrap: $(BOOTSTRAP_DEPS)
 
 bootstrap/%.yaml: $(KUSTOMIZE) $(HELM) $(MANIFESTS)
 	@echo "====> $@"

--- a/bootstrap/gs-kvm/gs-kvm.yaml
+++ b/bootstrap/gs-kvm/gs-kvm.yaml
@@ -11276,6 +11276,22 @@ spec:
     name: management-clusters-fleet
     namespace: flux-giantswarm
 ---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 10s
+  path: ./flux-manifests
+  prune: true
+  serviceAccountName: automation
+  sourceRef:
+    kind: GitRepository
+    name: rest-api-collection
+    namespace: flux-giantswarm
+  targetNamespace: giantswarm
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -11432,3 +11448,16 @@ spec:
   ref:
     branch: main
   url: https://github.com/giantswarm/management-clusters-fleet
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  secretRef:
+    name: github-giantswarm-https-credentials
+  url: https://github.com/giantswarm/rest-api-app-collection

--- a/bootstrap/gs-rest-api/gs-rest-api.yaml
+++ b/bootstrap/gs-rest-api/gs-rest-api.yaml
@@ -1,0 +1,29 @@
+# This is an auto-generated file. DO NOT EDIT
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 10s
+  path: ./flux-manifests
+  prune: true
+  serviceAccountName: automation
+  sourceRef:
+    kind: GitRepository
+    name: rest-api-collection
+    namespace: flux-giantswarm
+  targetNamespace: giantswarm
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  secretRef:
+    name: github-giantswarm-https-credentials
+  url: https://github.com/giantswarm/rest-api-app-collection

--- a/manifests/giantswarm/additional-rest-api-resources/gitrepository-rest-api-collection.yaml
+++ b/manifests/giantswarm/additional-rest-api-resources/gitrepository-rest-api-collection.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  secretRef:
+    name: github-giantswarm-https-credentials
+  url: https://github.com/giantswarm/rest-api-app-collection

--- a/manifests/giantswarm/additional-rest-api-resources/kustomization-rest-api-collection.yaml
+++ b/manifests/giantswarm/additional-rest-api-resources/kustomization-rest-api-collection.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: rest-api-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 10s
+  path: ./flux-manifests
+  prune: true
+  serviceAccountName: automation
+  sourceRef:
+    kind: GitRepository
+    name: rest-api-collection
+    namespace: flux-giantswarm
+  targetNamespace: giantswarm

--- a/manifests/giantswarm/additional-rest-api-resources/kustomization.yaml
+++ b/manifests/giantswarm/additional-rest-api-resources/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: "flux-giantswarm"
+resources:
+- gitrepository-rest-api-collection.yaml
+- kustomization-rest-api-collection.yaml

--- a/manifests/provider/gs-kvm/kustomization.yaml
+++ b/manifests/provider/gs-kvm/kustomization.yaml
@@ -1,5 +1,6 @@
 bases:
 - ../../giantswarm/additional-resources
+- ../../giantswarm/additional-rest-api-resources
 helmCharts:
   - name: flux-app
     includeCRDs: true

--- a/manifests/provider/gs-rest-api/kustomization.yaml
+++ b/manifests/provider/gs-rest-api/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+- ../../giantswarm/additional-rest-api-resources


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20991

Docs: https://github.com/giantswarm/giantswarm/pull/21015

For AWS MCs that need SSO the extra rest-api-collection is created via the `gs-rest-api` provider.

For KVM its added my default as we always need the REST API.

```
k get kustomization -n flux-giantswarm
NAME                  READY     STATUS                                                              AGE
collection            True      Applied revision: master/c98735e0450ddffc558ccbd2e80ee49283941acd   11d
customer-flux         True      Applied revision: main/81dd240b7cc4817d92c79fed17b992fad96ea318     11d
flux                  True      Applied revision: main/81dd240b7cc4817d92c79fed17b992fad96ea318     11d
rest-api-collection   Unknown   reconciliation in progress
```