### PR TITLE
fix command typo

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -14,7 +14,7 @@ manifests/flux-app: FLUXAPP_VERSION := v0.7.1
 manifests/flux-app:
 	@echo "====> $@"
 	git clean -fxd manifests/provider/
-	find manifests/provider/ -wholename '*/kustomization.yaml' | grep -v 'charts' | xargs -I{} gsed -i "0,/version:/{s/version: .*/version: $(FLUXAPP_VERSION)/g}" {}
+	find manifests/provider/ -wholename '*/kustomization.yaml' | grep -v 'charts' | xargs -I{} sed -i "0,/version:/{s/version: .*/version: $(FLUXAPP_VERSION)/g}" {}
 
 BOOTSTRAP_DEPS :=
 BOOTSTRAP_DEPS += bootstrap/customer-aws/customer-aws.yaml


### PR DESCRIPTION
gsed is not a valid command but sed is. 

This breaks the build command.