### PR TITLE
Fix bin/helm make target

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -56,6 +56,7 @@ $(KUSTOMIZE): ## Download kustomize locally if necessary.
 
 $(HELM): ## Download helm locally if necessary.
 	@echo "====> $@"
+	mkdir -p ./bin
 	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | HELM_INSTALL_DIR=bin USE_SUDO=false bash
 
 # go-get-tool will 'go get' any package $2 and install it to $1.


### PR DESCRIPTION
Otherwise:

```
$ make bin/helm
====> bin/helm
curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | HELM_INSTALL_DIR=bin USE_SUDO=false bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11156  100 11156    0     0  49029      0 --:--:-- --:--:-- --:--:-- 50940
Downloading https://get.helm.sh/helm-v3.8.2-darwin-amd64.tar.gz
Verifying checksum... Done.
Preparing to install helm into bin
cp: cannot create regular file 'bin/helm': No such file or directory
Failed to install helm
        For support, go to https://github.com/helm/helm.
make: *** [bin/helm] Error 1
```