### PR TITLE
Prevent kustomize-controller from pruning CRDs

### DIFF
--- a/bootstrap/gs-aws-china/gs-aws-china.yaml
+++ b/bootstrap/gs-aws-china/gs-aws-china.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-aws/gs-aws.yaml
+++ b/bootstrap/gs-aws/gs-aws.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -228,6 +229,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -487,6 +489,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -845,6 +848,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -1128,6 +1132,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -1909,6 +1914,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -2155,6 +2161,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -2745,6 +2752,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -3317,6 +3325,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -4122,6 +4131,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -5230,6 +5240,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -5434,6 +5445,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
@@ -6104,6 +6116,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6301,6 +6314,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6525,6 +6539,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6830,6 +6845,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7071,6 +7087,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7646,6 +7663,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7854,6 +7872,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -8309,6 +8328,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -8752,6 +8772,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -9385,6 +9406,7 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -10250,6 +10272,7 @@ data:
     metadata:
       annotations:
         controller-gen.kubebuilder.io/version: v0.7.0
+        kustomize.toolkit.fluxcd.io/prune: disabled
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: flux-system
@@ -10437,6 +10460,7 @@ data:
     metadata:
       annotations:
         controller-gen.kubebuilder.io/version: v0.7.0
+        kustomize.toolkit.fluxcd.io/prune: disabled
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-aws/gs-aws.yaml
+++ b/bootstrap/gs-aws/gs-aws.yaml
@@ -229,8 +229,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -489,8 +489,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -848,8 +848,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1132,8 +1132,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1914,8 +1914,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2161,8 +2161,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2752,8 +2752,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3325,8 +3325,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4131,8 +4131,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5240,8 +5240,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5445,8 +5445,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -6116,7 +6116,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6314,7 +6313,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6539,7 +6537,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -6845,7 +6842,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7087,7 +7083,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7663,7 +7658,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -7872,7 +7866,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -8328,7 +8321,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -8772,7 +8764,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -9406,7 +9397,6 @@ data:
     kind: CustomResourceDefinition
     metadata:
       annotations:
-        kustomize.toolkit.fluxcd.io/prune: disabled
         controller-gen.kubebuilder.io/version: v0.7.0
       creationTimestamp: null
       labels:
@@ -10272,7 +10262,6 @@ data:
     metadata:
       annotations:
         controller-gen.kubebuilder.io/version: v0.7.0
-        kustomize.toolkit.fluxcd.io/prune: disabled
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: flux-system
@@ -10460,7 +10449,6 @@ data:
     metadata:
       annotations:
         controller-gen.kubebuilder.io/version: v0.7.0
-        kustomize.toolkit.fluxcd.io/prune: disabled
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-azure/gs-azure.yaml
+++ b/bootstrap/gs-azure/gs-azure.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-gcp/gs-gcp.yaml
+++ b/bootstrap/gs-gcp/gs-gcp.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-kvm/gs-kvm.yaml
+++ b/bootstrap/gs-kvm/gs-kvm.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-openstack/gs-openstack.yaml
+++ b/bootstrap/gs-openstack/gs-openstack.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/bootstrap/gs-vsphere/gs-vsphere.yaml
+++ b/bootstrap/gs-vsphere/gs-vsphere.yaml
@@ -9,6 +9,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -229,6 +230,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -488,6 +490,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -846,6 +849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1129,6 +1133,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -1910,6 +1915,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2156,6 +2162,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -2746,6 +2753,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -3318,6 +3326,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -4123,6 +4132,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5231,6 +5241,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -5435,6 +5446,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+    kustomize.toolkit.fluxcd.io/prune: disabled
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system

--- a/manifests/provider/gs-aws-china/kustomization.yaml
+++ b/manifests/provider/gs-aws-china/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-aws/kustomization.yaml
+++ b/manifests/provider/gs-aws/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-azure/kustomization.yaml
+++ b/manifests/provider/gs-azure/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-gcp/kustomization.yaml
+++ b/manifests/provider/gs-gcp/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-kvm/kustomization.yaml
+++ b/manifests/provider/gs-kvm/kustomization.yaml
@@ -48,6 +48,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-openstack/kustomization.yaml
+++ b/manifests/provider/gs-openstack/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/provider/gs-vsphere/kustomization.yaml
+++ b/manifests/provider/gs-vsphere/kustomization.yaml
@@ -47,6 +47,14 @@ patches:
     - op: replace
       path: /roleRef/name
       value: crd-controller-giantswarm
+- target:
+    kind: CustomResourceDefinition
+    name: ".*"
+  patch: |-
+    - op: add
+      # https://github.com/kubernetes-sigs/kustomize/issues/1256
+      path: /metadata/annotations/kustomize.toolkit.fluxcd.io~1prune
+      value: disabled
 patchesJson6902:
   - target:
       group: apps


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22052

This is a one-time-operation. CRD definitions will be updated only via a Job once #99 is merged.
