### PR TITLE
Fixing Kyverno policy

### DIFF
--- a/bootstrap/customer-aws-china/customer-aws-china.yaml
+++ b/bootstrap/customer-aws-china/customer-aws-china.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-aws/customer-aws.yaml
+++ b/bootstrap/customer-aws/customer-aws.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-azure/customer-azure.yaml
+++ b/bootstrap/customer-azure/customer-azure.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-gcp/customer-gcp.yaml
+++ b/bootstrap/customer-gcp/customer-gcp.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-kvm/customer-kvm.yaml
+++ b/bootstrap/customer-kvm/customer-kvm.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-openstack/customer-openstack.yaml
+++ b/bootstrap/customer-openstack/customer-openstack.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/bootstrap/customer-vsphere/customer-vsphere.yaml
+++ b/bootstrap/customer-vsphere/customer-vsphere.yaml
@@ -1116,10 +1116,15 @@ spec:
         - HelmRelease
     name: serviceAccountNameMustBeSet
     validate:
-      message: .spec.serviceAccountName is required
-      pattern:
-        spec:
+      anyPattern:
+      - spec:
           serviceAccountName: ?*
+      - spec:
+          kubeConfig:
+            secretRef:
+              name: ?*
+      message: either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name
+        is required
   - exclude:
       resources:
         namespaces:

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -19,7 +19,7 @@ spec:
             - Kustomization
             - HelmRelease
       validate:
-        message: ".spec.serviceAccountName is required"
+        message: "either .spec.serviceAccountName or .spec.kubeConfig.secretRef.name is required"
         anyPattern:
         - spec:
             serviceAccountName: "?*"

--- a/manifests/customer/additional-resources/kyverno-policies.yaml
+++ b/manifests/customer/additional-resources/kyverno-policies.yaml
@@ -20,9 +20,13 @@ spec:
             - HelmRelease
       validate:
         message: ".spec.serviceAccountName is required"
-        pattern:
-          spec:
+        anyPattern:
+        - spec:
             serviceAccountName: "?*"
+        - spec:
+            kubeConfig:
+              secretRef:
+                name: "?*"
     - name: kustomizationSourceRefNamespaceIsSafe
       exclude:
         resources:
@@ -214,4 +218,3 @@ spec:
           spec:
             imageRepositoryRef:
               namespace: "{{request.object.metadata.namespace}}"
-

--- a/tests/kyverno/kyverno-test.yaml
+++ b/tests/kyverno/kyverno-test.yaml
@@ -1,0 +1,26 @@
+name: mytests
+policies:
+  - ../../manifests/customer/additional-resources/kyverno-policies.yaml
+resources:
+  - resources/kustomization_bad.yaml
+  - resources/kustomization_sa.yaml
+  - resources/kustomization_kubeconfig.yaml
+results:
+- policy: flux-multi-tenancy
+  rule: serviceAccountNameMustBeSet
+  resource: kustomization-sa
+  namespace: default
+  kind: Kustomization
+  result: pass
+- policy: flux-multi-tenancy
+  rule: serviceAccountNameMustBeSet
+  resource: kustomization-kubeconfig
+  namespace: fake0
+  kind: Kustomization
+  result: pass
+- policy: flux-multi-tenancy
+  rule: serviceAccountNameMustBeSet
+  resource: kustomization-bad
+  namespace: default
+  kind: Kustomization
+  result: fail

--- a/tests/kyverno/resources/kustomization_bad.yaml
+++ b/tests/kyverno/resources/kustomization_bad.yaml
@@ -1,0 +1,15 @@
+# Kustomization does not use neither `kubeconfig` nor
+# `serviceaccountName` what makes it wrong.
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kustomization-bad
+  namespace: default
+spec:
+  interval: 1m
+  path: "./fake/path"
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: fake-repository
+  timeout: 2m

--- a/tests/kyverno/resources/kustomization_kubeconfig.yaml
+++ b/tests/kyverno/resources/kustomization_kubeconfig.yaml
@@ -1,0 +1,19 @@
+# Kustomization uses `kubeconfig` hence it does not
+# need `serviceAccountName`
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kustomization-kubeconfig
+  namespace: fake0
+spec:
+  interval: 1m
+  kubeConfig:
+    secretRef:
+      key: kubeConfig
+      name: fake0-kubeconfig
+  path: "./fake/path"
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: fake-repository
+  timeout: 2m

--- a/tests/kyverno/resources/kustomization_sa.yaml
+++ b/tests/kyverno/resources/kustomization_sa.yaml
@@ -1,0 +1,15 @@
+# Kustomization uses `serviceAccountName` so its ok.
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kustomization-sa
+  namespace: default
+spec:
+  interval: 1m
+  path: "./fake/path"
+  prune: false
+  serviceAccountName: automation
+  sourceRef:
+    kind: GitRepository
+    name: fake-repository
+  timeout: 2m


### PR DESCRIPTION
Currently when users specify the `kubeconfig` to use with Kustomization CR, it is still required of them to put the `serviceAccountName` what is wrong, because there is no need to when targeting remote cluster. This PR changes Kyverno Policies behavior and adds some tests.