### PR TITLE
Graduate source.toolkit.fluxcd.io/v1beta1 to v1beta2

### DIFF
--- a/bootstrap/gs-aws-china/gs-aws-china.yaml
+++ b/bootstrap/gs-aws-china/gs-aws-china.yaml
@@ -7099,7 +7099,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7113,7 +7113,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/aws-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7126,7 +7126,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/bootstrap/gs-aws/gs-aws.yaml
+++ b/bootstrap/gs-aws/gs-aws.yaml
@@ -7095,7 +7095,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7109,7 +7109,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/aws-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7122,7 +7122,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/bootstrap/gs-azure/gs-azure.yaml
+++ b/bootstrap/gs-azure/gs-azure.yaml
@@ -7095,7 +7095,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7109,7 +7109,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/azure-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7122,7 +7122,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/bootstrap/gs-gcp/gs-gcp.yaml
+++ b/bootstrap/gs-gcp/gs-gcp.yaml
@@ -7095,7 +7095,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7109,7 +7109,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/gcp-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7122,7 +7122,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/bootstrap/gs-kvm/gs-kvm.yaml
+++ b/bootstrap/gs-kvm/gs-kvm.yaml
@@ -7110,7 +7110,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7124,7 +7124,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/kvm-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7137,7 +7137,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet
@@ -7148,7 +7148,7 @@ spec:
     branch: main
   url: https://github.com/giantswarm/management-clusters-fleet
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: rest-api-collection

--- a/bootstrap/gs-openstack/gs-openstack.yaml
+++ b/bootstrap/gs-openstack/gs-openstack.yaml
@@ -7094,7 +7094,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7108,7 +7108,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/openstack-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7121,7 +7121,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/bootstrap/gs-rest-api/gs-rest-api.yaml
+++ b/bootstrap/gs-rest-api/gs-rest-api.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: flux-giantswarm
   targetNamespace: giantswarm
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: rest-api-collection

--- a/bootstrap/gs-vsphere/gs-vsphere.yaml
+++ b/bootstrap/gs-vsphere/gs-vsphere.yaml
@@ -7095,7 +7095,7 @@ spec:
   - Egress
   - Ingress
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection
@@ -7109,7 +7109,7 @@ spec:
   timeout: 5m
   url: https://github.com/giantswarm/vsphere-app-collection
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config
@@ -7122,7 +7122,7 @@ spec:
     name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/config
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/manifests/giantswarm/additional-resources/gitrepository-giantswarm-config.yaml
+++ b/manifests/giantswarm/additional-resources/gitrepository-giantswarm-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: giantswarm-config

--- a/manifests/giantswarm/additional-resources/gitrepository-management-clusters-fleet.yaml
+++ b/manifests/giantswarm/additional-resources/gitrepository-management-clusters-fleet.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: management-clusters-fleet

--- a/manifests/giantswarm/additional-rest-api-resources/gitrepository-rest-api-collection.yaml
+++ b/manifests/giantswarm/additional-rest-api-resources/gitrepository-rest-api-collection.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: rest-api-collection

--- a/manifests/provider/gs-aws-china/gitrepository-collection.yaml
+++ b/manifests/provider/gs-aws-china/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-aws/gitrepository-collection.yaml
+++ b/manifests/provider/gs-aws/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-azure/gitrepository-collection.yaml
+++ b/manifests/provider/gs-azure/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-gcp/gitrepository-collection.yaml
+++ b/manifests/provider/gs-gcp/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-kvm/gitrepository-collection.yaml
+++ b/manifests/provider/gs-kvm/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-openstack/gitrepository-collection.yaml
+++ b/manifests/provider/gs-openstack/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection

--- a/manifests/provider/gs-vsphere/gitrepository-collection.yaml
+++ b/manifests/provider/gs-vsphere/gitrepository-collection.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: collection


### PR DESCRIPTION
Follow-up to https://github.com/giantswarm/giantswarm/issues/22052

Flux will stop serving the `v1beta1` API in a couple of releases.
